### PR TITLE
joyent_url should be in compute initialization, not server creation

### DIFF
--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -70,6 +70,7 @@ module Kitchen
           joyent_username:  config[:joyent_username],
           joyent_keyname:   config[:joyent_keyname],
           joyent_keyfile:   config[:joyent_keyfile],
+          joyent_url:       config[:joyent_url],
         }
 
         Fog::Compute.new(server_def)
@@ -79,7 +80,6 @@ module Kitchen
         debug_server_config
 
         compute.servers.create(
-          joyent_url:       config[:joyent_url],
           dataset:          config[:joyent_image_id],
           package:          config[:joyent_flavor_id],
           )

--- a/spec/kitchen/driver/joyent_spec.rb
+++ b/spec/kitchen/driver/joyent_spec.rb
@@ -180,7 +180,8 @@ describe Kitchen::Driver::Joyent do
       {
         joyent_username: 'honeybadger',
         joyent_keyname: 'dontcare',
-        joyent_keyfile: 'dat.pem'
+        joyent_keyfile: 'dat.pem',
+        joyent_url: 'https://us-sw-1.api.joyentcloud.com'
       }
     end
 
@@ -221,7 +222,6 @@ describe Kitchen::Driver::Joyent do
   describe '#create_server' do
     let(:config) do
       {
-        joyent_url: 'https://us-sw-1.api.joyentcloud.com',
         dataset: '87b9f4ac-5385-11e3-a304-fb868b82fe10',
         package: 'g3-standard-4-smartos',
       }


### PR DESCRIPTION
fog was ignoring joyent_url set on the server create definition, so was always trying to spin up servers in the default (us-sw-1).
