### PR TITLE
Additional server connection and server options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Under `platforms` section:
 
     driver_config:
       # Allow self-signed certs.
-      # Possible warning from fog gem:
-      #   [fog][WARNING] Unrecognized arguments: joyent_ssl_verify_peer
       #
       joyent_ssl_verify_peer: false
       
@@ -49,6 +47,7 @@ Under `platforms` section:
         - a3a84a44-766c-407e-9233-9a45ebcd579f
         
       # For images without a default network (will throw error if invalid)
+      # NOTE: Don't use 'joyent_networks' if using this attribute.
       #
       joyent_default_networks:
         - d2ba0f30-bbe8-11e2-a9a2-6bc116856d85

--- a/README.md
+++ b/README.md
@@ -30,7 +30,34 @@ Provide, at a minimum, the required driver options in your `.kitchen.yml` file:
       
 Until we get SmartOS, OmniOS, and FreeBSD into Omnitruck, you'll need
 to override the Chef bootstrap script.
-      chef_omnibus_url: http://path.to.an.script.sh 
+      chef_omnibus_url: http://path.to.an.script.sh
+
+## Optional Attributes
+Under `platforms` section:
+
+    driver_config:
+      # Allow self-signed certs.
+      # Possible warning from fog gem:
+      #   [fog][WARNING] Unrecognized arguments: joyent_ssl_verify_peer
+      #
+      joyent_ssl_verify_peer: false
+      
+      # For additional nics
+      #
+      joyent_networks:
+        - d2ba0f30-bbe8-11e2-a9a2-6bc116856d85
+        - a3a84a44-766c-407e-9233-9a45ebcd579f
+        
+      # For images without a default network (will throw error if invalid)
+      #
+      joyent_default_networks:
+        - d2ba0f30-bbe8-11e2-a9a2-6bc116856d85
+        - a3a84a44-766c-407e-9233-9a45ebcd579f
+        
+Under `suites` section:
+
+    driver_config:
+      joyent_image_name: default01
 
 # Example .kitchen.yml
 

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -75,7 +75,9 @@ module Kitchen
           joyent_keyname:         config[:joyent_keyname],
           joyent_keyfile:         config[:joyent_keyfile],
           joyent_url:             config[:joyent_url],
-          joyent_ssl_verify_peer: config[:joyent_ssl_verify_peer],
+          connection_options:     {
+                                    ssl_verify_peer: config[:joyent_ssl_verify_peer],
+                                  },
         }
 
         Fog::Compute.new(server_def)

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -83,16 +83,20 @@ module Kitchen
 
       def create_server
         debug_server_config
-
-        compute.servers.create(
+        
+        compute_def = {
           dataset:          config[:joyent_image_id],
           package:          config[:joyent_flavor_id],
           name:             config[:joyent_image_name],
-          networks:         config[:joyent_networks],
-          if config[:joyent_default_networks].any?
-            default_networks: config[:joyent_default_networks],
-          end
-          )
+        }
+        
+        if config[:joyent_networks].any?
+          compute_def[:networks] = config[:joyent_networks]
+        elsif config[:joyent_default_networks].any?
+          compute_def[:default_networks] = config[:joyent_default_networks]
+        end
+
+        compute.servers.create(compute_def)
       end
 
       def debug_server_config

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -69,11 +69,12 @@ module Kitchen
         debug_compute_config
 
         server_def = {
-          provider:         :joyent,
-          joyent_username:  config[:joyent_username],
-          joyent_keyname:   config[:joyent_keyname],
-          joyent_keyfile:   config[:joyent_keyfile],
-          joyent_url:       config[:joyent_url],
+          provider:               :joyent,
+          joyent_username:        config[:joyent_username],
+          joyent_keyname:         config[:joyent_keyname],
+          joyent_keyfile:         config[:joyent_keyfile],
+          joyent_url:             config[:joyent_url],
+          joyent_ssl_verify_peer: config[:joyent_ssl_verify_peer],
         }
 
         Fog::Compute.new(server_def)

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -30,7 +30,10 @@ module Kitchen
     class Joyent < Kitchen::Driver::SSHBase
       default_config :joyent_url, 'https://us-sw-1.api.joyentcloud.com'
       default_config :joyent_image_id, '87b9f4ac-5385-11e3-a304-fb868b82fe10'
+      default_config :joyent_image_name, ''
       default_config :joyent_flavor_id, 'g3-standard-4-smartos'
+      default_config :joyent_networks, []
+      default_config :joyent_ssl_verify_peer, true
       default_config :username, 'root'
       default_config :port, '22'
       default_config :sudo, false
@@ -82,6 +85,8 @@ module Kitchen
         compute.servers.create(
           dataset:          config[:joyent_image_id],
           package:          config[:joyent_flavor_id],
+          name:             config[:joyent_image_name],
+          networks:         config[:joyent_networks],
           )
       end
 
@@ -89,6 +94,8 @@ module Kitchen
         debug("joyent: joyent_url #{config[:joyent_url]}")
         debug("joyent: image_id #{config[:joyent_image_id]}")
         debug("joyent: flavor_id #{config[:joyent_flavor_id]}")
+        debug("joyent: image_name #{config[:joyent_image_name]}")
+        debug("joyent: networks #{config[:joyent_networks]}")
       end
 
       def debug_compute_config

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -33,6 +33,7 @@ module Kitchen
       default_config :joyent_image_name, ''
       default_config :joyent_flavor_id, 'g3-standard-4-smartos'
       default_config :joyent_networks, []
+      default_config :joyent_default_networks, []
       default_config :joyent_ssl_verify_peer, true
       default_config :username, 'root'
       default_config :port, '22'
@@ -88,6 +89,7 @@ module Kitchen
           package:          config[:joyent_flavor_id],
           name:             config[:joyent_image_name],
           networks:         config[:joyent_networks],
+          default_networks: config[:joyent_default_networks],
           )
       end
 

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -87,7 +87,7 @@ module Kitchen
           dataset:          config[:joyent_image_id],
           package:          config[:joyent_flavor_id],
           name:             config[:joyent_image_name],
-          networks:         config[:joyent_networks],
+          default_networks: config[:joyent_networks],
           )
       end
 

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -103,8 +103,16 @@ module Kitchen
         debug("joyent: joyent_url #{config[:joyent_url]}")
         debug("joyent: image_id #{config[:joyent_image_id]}")
         debug("joyent: flavor_id #{config[:joyent_flavor_id]}")
-        debug("joyent: image_name #{config[:joyent_image_name]}")
-        debug("joyent: networks #{config[:joyent_networks]}")
+        
+        unless config[:joyent_image_name].length == 0
+          debug("joyent: image_name #{config[:joyent_image_name]}")
+        end
+        if config[:joyent_networks].any?
+          debug("joyent: networks #{config[:joyent_networks]}")
+        end
+        if config[:joyent_default_networks].any?
+          debug("joyent: default_networks #{config[:joyent_networks]}")
+        end
       end
 
       def debug_compute_config

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -89,7 +89,9 @@ module Kitchen
           package:          config[:joyent_flavor_id],
           name:             config[:joyent_image_name],
           networks:         config[:joyent_networks],
-          default_networks: config[:joyent_default_networks],
+          if config[:joyent_default_networks].any?
+            default_networks: config[:joyent_default_networks],
+          end
           )
       end
 

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -87,7 +87,7 @@ module Kitchen
           dataset:          config[:joyent_image_id],
           package:          config[:joyent_flavor_id],
           name:             config[:joyent_image_name],
-          default_networks: config[:joyent_networks],
+          networks:         config[:joyent_networks],
           )
       end
 


### PR DESCRIPTION
Additional functionality includes:
* Allowing self-signed certificate on server via:
  * `joyent_ssl_verify_peer`
* Additional networks via: 
  * `joyent_networks`
* Default networks if needed via: 
  * `joyent_default_networks`
* Add instance name via: 
  * `joyent_image_name`
