### PR TITLE
Allow Joyent API version to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,31 +33,35 @@ to override the Chef bootstrap script.
       chef_omnibus_url: http://path.to.an.script.sh
 
 ## Optional Attributes
-Under `platforms` section:
+Under the general `driver_config`:
+````
+# Specify Joyent API version
+joyent_version: '~7.0'
 
-    driver_config:
-      # Allow self-signed certs.
-      #
-      joyent_ssl_verify_peer: false
-      
-      # For additional nics
-      #
-      joyent_networks:
-        - d2ba0f30-bbe8-11e2-a9a2-6bc116856d85
-        - a3a84a44-766c-407e-9233-9a45ebcd579f
-        
-      # For images without a default network (will throw error if invalid)
-      # NOTE: Don't use 'joyent_networks' if using this attribute.
-      #
-      joyent_default_networks:
-        - d2ba0f30-bbe8-11e2-a9a2-6bc116856d85
-        - a3a84a44-766c-407e-9233-9a45ebcd579f
-        
-Under `suites` section:
+# Allow self-signed certs.
+joyent_ssl_verify_peer: false
+````
+Usually under `platforms` section:
+````
+driver_config:
 
-    driver_config:
-      joyent_image_name: default01
+  # For additional nics
+  # NOTE: Requires Joyent API version >= 7.0
+  joyent_networks:
+    - d2ba0f30-bbe8-11e2-a9a2-6bc116856d85
+    - a3a84a44-766c-407e-9233-9a45ebcd579f
+    
+  # Where to pull IP's from by default (internal/external)
+  joyent_default_networks:
+    - internal
+```
+Usually under `suites` section:
+```
+driver_config:
 
+  # Friendly machine name
+  joyent_image_name: default01
+```
 # Example .kitchen.yml
 
 ```

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -32,6 +32,7 @@ module Kitchen
       default_config :joyent_image_id, '87b9f4ac-5385-11e3-a304-fb868b82fe10'
       default_config :joyent_image_name, ''
       default_config :joyent_flavor_id, 'g3-standard-4-smartos'
+      default_config :joyent_version, '~6.5'
       default_config :joyent_networks, []
       default_config :joyent_default_networks, []
       default_config :joyent_ssl_verify_peer, true
@@ -75,6 +76,7 @@ module Kitchen
           joyent_keyname:         config[:joyent_keyname],
           joyent_keyfile:         config[:joyent_keyfile],
           joyent_url:             config[:joyent_url],
+          joyent_version:         config[:joyent_version],
           connection_options:     {
                                     ssl_verify_peer: config[:joyent_ssl_verify_peer],
                                   },
@@ -92,9 +94,13 @@ module Kitchen
           name:             config[:joyent_image_name],
         }
         
+        # Requires "joyent_version" >= 7.0
         if config[:joyent_networks].any?
           compute_def[:networks] = config[:joyent_networks]
-        elsif config[:joyent_default_networks].any?
+        end
+        
+        # "internal" and/or "external"
+        if config[:joyent_default_networks].any?
           compute_def[:default_networks] = config[:joyent_default_networks]
         end
 
@@ -105,6 +111,7 @@ module Kitchen
         debug("joyent: joyent_url #{config[:joyent_url]}")
         debug("joyent: image_id #{config[:joyent_image_id]}")
         debug("joyent: flavor_id #{config[:joyent_flavor_id]}")
+        debug("joyent: version #{config[:joyent_version]}")
         
         unless config[:joyent_image_name].length == 0
           debug("joyent: image_name #{config[:joyent_image_name]}")


### PR DESCRIPTION
Fixes a problem where `joyent_networks` wouldn't work because the default API version is `'~6.5'` when it requires a version >= 7.0

Other minor cleanup was done in `lib/kitchen/driver/joyent.rb`