### PR TITLE
Invalid characters dropped for joyent_image_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Usually under `suites` section:
 driver_config:
 
   # Friendly machine name
+  # Valid Chracters =~ /0-9A-Za-z\.-/
   joyent_image_name: default01
 ```
 # Example .kitchen.yml

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -91,7 +91,7 @@ module Kitchen
         compute_def = {
           dataset:          config[:joyent_image_id],
           package:          config[:joyent_flavor_id],
-          name:             config[:joyent_image_name],
+          name:             config[:joyent_image_name].gsub!(/_/, '-').gsub!(/[^0-9A-Za-z\.-]/, ''),
         }
         
         # Requires "joyent_version" >= 7.0


### PR DESCRIPTION
Underscores `'_'` will be replaced with dashes `'-'`

All other characters that don't match `/0-9A-Za-z\.-/` will be dropped.