### PR TITLE
Wrong use of 'gsub'

### DIFF
--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -91,7 +91,7 @@ module Kitchen
         compute_def = {
           dataset:          config[:joyent_image_id],
           package:          config[:joyent_flavor_id],
-          name:             config[:joyent_image_name].gsub!(/_/, '-').gsub!(/[^0-9A-Za-z\.-]/, ''),
+          name:             config[:joyent_image_name].gsub(/_/, '-').gsub(/[^0-9A-Za-z\.-]/, ''),
         }
         
         # Requires "joyent_version" >= 7.0


### PR DESCRIPTION
I must have been excited because those exclamation marks are not supposed to be there.  It was causing an issue where a valid name would actually be returned as `nil` after the `gsub`.