### PR TITLE
Updated naming, added metadata and tagging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ to override the Chef bootstrap script.
 
 ## Optional Attributes
 Under the general `driver_config`:
-````
+````yaml
 # Specify Joyent API version
 joyent_version: '~7.0'
 
@@ -42,7 +42,7 @@ joyent_version: '~7.0'
 joyent_ssl_verify_peer: false
 ````
 Usually under `platforms` section:
-````
+````yaml
 driver_config:
 
   # For additional nics
@@ -56,16 +56,24 @@ driver_config:
     - internal
 ```
 Usually under `suites` section:
-```
+```yaml
 driver_config:
 
-  # Friendly machine name
+  # Friendly machine name (defaults to: "<joyent_username>-<suite>-<platform>")
   # Valid Chracters =~ /0-9A-Za-z\.-/
   joyent_image_name: default01
+  
+  # Metadata for the machine
+  joyent_image_metadata:
+    user1_pw: password
+
+  # Insert Tags for the machine
+  joyent_image_tags:
+    role: testing
 ```
 # Example .kitchen.yml
 
-```
+```yaml
 ---
 driver_plugin: joyent
 driver_config:

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -21,6 +21,7 @@ require 'fog'
 require 'kitchen'
 require 'etc'
 require 'socket'
+require 'securerandom'
 
 module Kitchen
   module Driver
@@ -91,7 +92,7 @@ module Kitchen
         debug_server_config
         
         if config[:joyent_image_name].nil?
-          config[:joyent_image_name] = "#{config[:joyent_username].gsub(/[^0-9A-Za-z\-]/, '')}-#{instance.name}"
+          config[:joyent_image_name] = "#{config[:joyent_username].gsub(/[^0-9A-Za-z\-]/, '')}-#{instance.name}-#{SecureRandom.hex(3)}"
         else
           config[:joyent_image_name] = config[:joyent_image_name].gsub(/_/, '-').gsub(/[^0-9A-Za-z\.-]/, '')
         end

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -31,6 +31,8 @@ module Kitchen
       default_config :joyent_url, 'https://us-sw-1.api.joyentcloud.com'
       default_config :joyent_image_id, '87b9f4ac-5385-11e3-a304-fb868b82fe10'
       default_config :joyent_image_name, nil
+      default_config :joyent_image_tags, {}
+      default_config :joyent_image_metadata, {}
       default_config :joyent_flavor_id, 'g3-standard-4-smartos'
       default_config :joyent_version, '~6.5'
       default_config :joyent_networks, []
@@ -108,6 +110,17 @@ module Kitchen
         # "internal" and/or "external"
         if config[:joyent_default_networks].any?
           compute_def[:default_networks] = config[:joyent_default_networks]
+        end
+        
+        # Adds "Customer Metadata" fields to machine.
+        # TODO: Figure out how to override "Internal Metadata"
+        config[:joyent_image_metadata].each do |key, value|
+          compute_def["metadata.#{key}"] = value
+        end
+
+        # Adds tags to machine
+        config[:joyent_image_tags].each do |key, value|
+          compute_def["tag.#{key}"] = value
         end
 
         compute.servers.create(compute_def)

--- a/lib/kitchen/driver/joyent.rb
+++ b/lib/kitchen/driver/joyent.rb
@@ -30,7 +30,7 @@ module Kitchen
     class Joyent < Kitchen::Driver::SSHBase
       default_config :joyent_url, 'https://us-sw-1.api.joyentcloud.com'
       default_config :joyent_image_id, '87b9f4ac-5385-11e3-a304-fb868b82fe10'
-      default_config :joyent_image_name, ''
+      default_config :joyent_image_name, nil
       default_config :joyent_flavor_id, 'g3-standard-4-smartos'
       default_config :joyent_version, '~6.5'
       default_config :joyent_networks, []
@@ -88,10 +88,16 @@ module Kitchen
       def create_server
         debug_server_config
         
+        if config[:joyent_image_name].nil?
+          config[:joyent_image_name] = "#{config[:joyent_username].gsub(/[^0-9A-Za-z\-]/, '')}-#{instance.name}"
+        else
+          config[:joyent_image_name] = config[:joyent_image_name].gsub(/_/, '-').gsub(/[^0-9A-Za-z\.-]/, '')
+        end
+        
         compute_def = {
           dataset:          config[:joyent_image_id],
           package:          config[:joyent_flavor_id],
-          name:             config[:joyent_image_name].gsub(/_/, '-').gsub(/[^0-9A-Za-z\.-]/, ''),
+          name:             config[:joyent_image_name],
         }
         
         # Requires "joyent_version" >= 7.0
@@ -113,7 +119,7 @@ module Kitchen
         debug("joyent: flavor_id #{config[:joyent_flavor_id]}")
         debug("joyent: version #{config[:joyent_version]}")
         
-        unless config[:joyent_image_name].length == 0
+        unless config[:joyent_image_name].nil?
           debug("joyent: image_name #{config[:joyent_image_name]}")
         end
         if config[:joyent_networks].any?


### PR DESCRIPTION
**Updated:**
`joyent_image_name` 
- Now automatically assigned,
- Defaults to: `<joyent_username>-<suite>-<platform>`

**New:**
`joyent_image_metadata`
- Adds custom metadata fields to machines

`joyent_image_tags`
- Adds custom tags to machines
